### PR TITLE
Fixed owner link in model view page

### DIFF
--- a/OGV/client/views/model_viewer.js
+++ b/OGV/client/views/model_viewer.js
@@ -55,10 +55,7 @@ Template.modelViewer.events({
 
     'click #sm-item-owner':function() 
     {
-    var parts = location.href.split('/');
-    //id of user whose page is being visited
-    var ownerId = parts.pop();         
-    goToOwner(ownerId);
+	ownerId();
     }
 
 });


### PR DESCRIPTION
The owner link in model viewer page went to 404 page.
Now it goes to the profile page of the model owner.