### PR TITLE
Support default g-obj binary, add option to enable mtl generation

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -1,3 +1,4 @@
 {
-  "adminPassword": "your_password_here"
+  "adminPassword": "your_password_here",
+  "generateTextures": false
 }


### PR DESCRIPTION
Now OGV will convert models without patched g-obj converter.
To enable texture generation I added an option `generateTextures` to config.json. 