### PR TITLE
Fixed edit link

### DIFF
--- a/imports/ui/components/model_post.html
+++ b/imports/ui/components/model_post.html
@@ -12,7 +12,7 @@
 			 	{{ owner.profile.name }}
 			 </a> posted {{/if}}
 			<div style="float: right;line-height: 32px">
-				<a href="/description/{{postId}}"><i class="mdi mdi-pencil"></i>Edit</a>
+				<a href="/description/{{model._id}}"><i class="mdi mdi-pencil"></i>Edit</a>
 				<a href id="deleteModel"><i class="mdi mdi-delete"></i>Delete</a>
 			</div>
 		</div>


### PR DESCRIPTION
This PR fixes the issue of the broken edit link of the Model. The issue is defined [here](https://github.com/BRL-CAD/OGV-meteor/issues/71) When the user clicks on `Edit` on the uploaded model the link redirects to the 404 page. 